### PR TITLE
Launcher3: Adjust the values for blur-depth radius

### DIFF
--- a/res/xml/launcher_misc_preferences.xml
+++ b/res/xml/launcher_misc_preferences.xml
@@ -52,9 +52,9 @@
         android:summary="@string/background_blur_summary"
         android:persistent="true"
         android:max="225"
-        android:min="85"
+        android:min="0"
         settings:units="px"
-        android:defaultValue="85" />
+        android:defaultValue="65" />
 
     <androidx.preference.PreferenceScreen
         android:key="pref_developer_options"


### PR DESCRIPTION
 * Allow to set no blur decreasing the minimum to 0
 * Make the UI more consistent setting the default value to 65px